### PR TITLE
[Extract] Added option to use full paths for decompress()-method.

### DIFF
--- a/SevenZipArchive.php
+++ b/SevenZipArchive.php
@@ -122,10 +122,12 @@ class SevenZipArchive
         }
     }
 
-    public function decompress()
+    public function decompress($withFullPath=false)
     {
+        $extractFlag = $withFullPath ? 'x' : 'e';
+
         $command = '"' . $this->_executablePath . '"'
-                 . ' e'
+                 . " {$extractFlag}"
                  . ' -y'
                  . $this->_getPasswordParam()
                  . ' ' . escapeshellarg($this->_archivePath)


### PR DESCRIPTION
While **keeping default behaviour** - added the possibility to extract archived files with their full paths to the method 'decompress()' which closes #2.